### PR TITLE
Update LICENSE to include Creative Commons for non-code outputs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,21 +1,41 @@
-MIT License
+# LICENSE
+
+## 1. Code / Software (MIT License)
 
 Copyright (c) 2026 Group 12, UBC DSCI 310
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+- The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+**Applies to:** All `.R` scripts, `Makefile`, `Dockerfile`, and other code/software artifacts in this repository.
+
+---
+
+## 2. Non-Code / Creative Works (CC BY-SA 4.0)
+
+The text, tables, figures, plots, and Quarto report files (including `salary_analysis.qmd` and `salary_analysis.html`) are licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0).
+
+You are free to:
+
+- **Share** — copy and redistribute the material in any medium or format  
+- **Adapt** — remix, transform, and build upon the material for any purpose, even commercially  
+
+Under the following terms:
+
+- **Attribution** — You must give appropriate credit, provide a link to the license, and indicate if changes were made.  
+- **ShareAlike** — If you remix, transform, or build upon the material, you must distribute your contributions under the same license.
+
+More information: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+**Applies to:** Quarto report, figures, tables, and other non-code outputs in the repository.
+
+---
+
+## 3. Disclaimer
+
+- The authors do not guarantee the accuracy of the non-code content.  
+- Any use of the code or creative works is at your own risk.  
+- The license does not affect your fair use rights or other limitations under copyright law.


### PR DESCRIPTION
- Added a Creative Commons Attribution-ShareAlike 4.0 license for non-code outputs (Quarto reports, figures, tables, and other creative works).  
- Clarified that MIT license applies only to code/software (R scripts, Makefile, Dockerfile, etc.).  
- Added a disclaimer covering both code and non-code content.  

This update addresses the milestone 1 feedback regarding specifying how non-code/software work can be used, shared, and derived.